### PR TITLE
fix: enable callback_query polling and add debug logs

### DIFF
--- a/src/channel/telegram/telegram-channel.ts
+++ b/src/channel/telegram/telegram-channel.ts
@@ -46,7 +46,12 @@ export class TelegramChannel implements NotificationChannel {
     this.stateManager = deps?.stateManager ?? null;
     this.tmuxBridge = deps?.tmuxBridge ?? null;
     this.registry = deps?.registry ?? null;
-    this.bot = new TelegramBot(cfg.telegram_bot_token, { polling: false });
+    this.bot = new TelegramBot(cfg.telegram_bot_token, {
+      polling: {
+        autoStart: false,
+        params: { allowed_updates: ["message", "callback_query"] },
+      },
+    });
     this.chatId = ConfigManager.loadChatState().chat_id;
     this.registerHandlers();
     this.registerChatHandlers();
@@ -209,7 +214,13 @@ export class TelegramChannel implements NotificationChannel {
   private registerChatHandlers(): void {
     this.bot.on("callback_query", async (query) => {
       try {
-        if (!ConfigManager.isOwner(this.cfg, query.from.id)) return;
+        logDebug(
+          `[TG:callback] id=${query.id} from=${query.from.id} data=${query.data ?? "(none)"}`
+        );
+        if (!ConfigManager.isOwner(this.cfg, query.from.id)) {
+          logDebug(`[TG:callback] dropped: unauthorized userId=${query.from.id}`);
+          return;
+        }
 
         if (query.data?.startsWith("aq:") || query.data?.startsWith("am:")) {
           await this.askQuestionHandler?.handleCallback(query);
@@ -324,9 +335,21 @@ export class TelegramChannel implements NotificationChannel {
     });
 
     this.bot.on("message", async (msg) => {
-      if (!msg.reply_to_message) return;
-      if (!msg.text) return;
-      if (!ConfigManager.isOwner(this.cfg, msg.from?.id ?? 0)) return;
+      logDebug(
+        `[TG:msg] msgId=${msg.message_id} from=${msg.from?.id ?? "?"} chatId=${msg.chat.id} hasReply=${!!msg.reply_to_message} hasText=${!!msg.text}`
+      );
+      if (!msg.reply_to_message) {
+        logDebug(`[TG:msg] dropped: no reply_to_message msgId=${msg.message_id}`);
+        return;
+      }
+      if (!msg.text) {
+        logDebug(`[TG:msg] dropped: no text msgId=${msg.message_id}`);
+        return;
+      }
+      if (!ConfigManager.isOwner(this.cfg, msg.from?.id ?? 0)) {
+        logDebug(`[TG:msg] dropped: unauthorized userId=${msg.from?.id ?? "?"}`);
+        return;
+      }
 
       logDebug(
         `[Chat:msg] replyTo=${msg.reply_to_message.message_id} text="${msg.text.slice(0, 50)}"`
@@ -344,7 +367,12 @@ export class TelegramChannel implements NotificationChannel {
       }
 
       const pending = this.pendingReplyStore.get(msg.chat.id, msg.reply_to_message.message_id);
-      if (!pending) return;
+      if (!pending) {
+        logDebug(
+          `[TG:msg] dropped: no pending reply for chatId=${msg.chat.id} replyToMsgId=${msg.reply_to_message.message_id}`
+        );
+        return;
+      }
 
       this.pendingReplyStore.delete(msg.chat.id, msg.reply_to_message.message_id);
       this.bot.deleteMessage(msg.chat.id, msg.reply_to_message.message_id).catch(() => {});

--- a/src/server/api-server.ts
+++ b/src/server/api-server.ts
@@ -6,7 +6,7 @@ import { AgentHandler } from "../agent/agent-handler.js";
 import { AgentName } from "../agent/types.js";
 import { t } from "../i18n/index.js";
 import { ApiRoute, MINI_APP_BASE_URL } from "../utils/constants.js";
-import { log, logError } from "../utils/log.js";
+import { log, logDebug, logError } from "../utils/log.js";
 import { responseStore } from "../utils/response-store.js";
 import type { TunnelManager } from "../utils/tunnel.js";
 
@@ -65,6 +65,9 @@ export class ApiServer {
     const app = express();
     app.use(express.json({ limit: "10mb" }));
     app.get(ApiRoute.ResponseData, (req, res) => {
+      logDebug(
+        `[API] GET ${ApiRoute.ResponseData} id=${req.params.id} origin=${req.headers.origin ?? "none"}`
+      );
       const requestOrigin = req.headers.origin ?? "";
       const tunnelUrl = this.tunnelManager?.getPublicUrl();
       const tunnelOrigin = tunnelUrl ? new URL(tunnelUrl).origin : null;
@@ -84,13 +87,16 @@ export class ApiServer {
     });
 
     app.post(ApiRoute.HookStop, (req, res) => {
+      logDebug(`[API] POST ${ApiRoute.HookStop} ip=${req.ip} agent=${req.query.agent ?? "(none)"}`);
       const receivedSecret = req.headers["x-ccpoke-secret"];
       if (receivedSecret !== this.secret) {
+        logDebug(`[API] forbidden: secret mismatch on ${ApiRoute.HookStop}`);
         res.status(403).send("forbidden");
         return;
       }
 
       const agentName = req.query.agent ? `${req.query.agent}` : AgentName.ClaudeCode;
+      logDebug(`[API] ${ApiRoute.HookStop} accepted agent=${agentName}`);
 
       setImmediate(() => {
         this.handler?.handleStopEvent(agentName, req.body).catch((err: unknown) => {
@@ -101,12 +107,17 @@ export class ApiServer {
     });
 
     app.post(ApiRoute.HookSessionStart, (req, res) => {
+      logDebug(
+        `[API] POST ${ApiRoute.HookSessionStart} ip=${req.ip} sessionId=${req.body?.session_id ?? "?"}`
+      );
       const receivedSecret = req.headers["x-ccpoke-secret"];
       if (receivedSecret !== this.secret) {
+        logDebug(`[API] forbidden: secret mismatch on ${ApiRoute.HookSessionStart}`);
         res.status(403).send("forbidden");
         return;
       }
 
+      logDebug(`[API] ${ApiRoute.HookSessionStart} accepted`);
       setImmediate(() => {
         this.handler?.handleSessionStart(req.body).catch((err: unknown) => {
           logError(t("hook.sessionStartFailed"), err);
@@ -116,12 +127,17 @@ export class ApiServer {
     });
 
     app.post(ApiRoute.HookNotification, (req, res) => {
+      logDebug(
+        `[API] POST ${ApiRoute.HookNotification} ip=${req.ip} sessionId=${req.body?.session_id ?? "?"}`
+      );
       const receivedSecret = req.headers["x-ccpoke-secret"];
       if (receivedSecret !== this.secret) {
+        logDebug(`[API] forbidden: secret mismatch on ${ApiRoute.HookNotification}`);
         res.status(403).send("forbidden");
         return;
       }
 
+      logDebug(`[API] ${ApiRoute.HookNotification} accepted`);
       setImmediate(() => {
         this.handler?.handleNotification(req.body).catch((err: unknown) => {
           logError(t("hook.notificationHookFailed"), err);
@@ -131,12 +147,17 @@ export class ApiServer {
     });
 
     app.post(ApiRoute.HookAskUserQuestion, (req, res) => {
+      logDebug(
+        `[API] POST ${ApiRoute.HookAskUserQuestion} ip=${req.ip} sessionId=${req.body?.session_id ?? "?"}`
+      );
       const receivedSecret = req.headers["x-ccpoke-secret"];
       if (receivedSecret !== this.secret) {
+        logDebug(`[API] forbidden: secret mismatch on ${ApiRoute.HookAskUserQuestion}`);
         res.status(403).send("forbidden");
         return;
       }
 
+      logDebug(`[API] ${ApiRoute.HookAskUserQuestion} accepted`);
       setImmediate(() => {
         this.handler?.handleAskUserQuestion(req.body).catch((err: unknown) => {
           logError(t("askQuestion.hookFailed"), err);
@@ -146,12 +167,17 @@ export class ApiServer {
     });
 
     app.post(ApiRoute.HookPermissionRequest, (req, res) => {
+      logDebug(
+        `[API] POST ${ApiRoute.HookPermissionRequest} ip=${req.ip} sessionId=${req.body?.session_id ?? "?"}`
+      );
       const receivedSecret = req.headers["x-ccpoke-secret"];
       if (receivedSecret !== this.secret) {
+        logDebug(`[API] forbidden: secret mismatch on ${ApiRoute.HookPermissionRequest}`);
         res.status(403).send("forbidden");
         return;
       }
 
+      logDebug(`[API] ${ApiRoute.HookPermissionRequest} accepted`);
       setImmediate(() => {
         this.handler?.handlePermissionRequest(req.body).catch((err: unknown) => {
           logError(t("hook.permissionRequestFailed"), err);
@@ -161,6 +187,7 @@ export class ApiServer {
     });
 
     app.get(ApiRoute.Health, (_req, res) => {
+      logDebug(`[API] GET ${ApiRoute.Health}`);
       res.status(200).send("healthy");
     });
 


### PR DESCRIPTION
- Fix Telegram inline button callbacks not being received by explicitly
  setting allowed_updates: ['message', 'callback_query'] in the bot
  constructor's polling options. The internal TelegramBotPolling class
  reads bot.options.polling at construction time and ignores options
  passed to startPolling(), so the config must live in the constructor.

- Add debug logging (LOG_LEVEL=debug) to trace both failure flows:
  - api-server: log every incoming request, accepted/forbidden status,
    and secret mismatch on all hook routes (/hook/stop, /hook/session-start,
    /hook/notification, /hook/ask-user-question, /hook/permission-request)
  - telegram-channel: log entry + drop reason for every message/callback_query
    event (no reply_to_message, no text, unauthorized, no pending reply)